### PR TITLE
Allow ingress to be configured to route all traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following table lists the configurable parameters of the FME Server 2018.1.0
 | `deployment.numCores` | Number of cores to launch. Multi-core only works in a multi-host cluster with ReadWriteMany storage | `1` |
 | `deployment.numEngine` | Number of engines to launch. | `2` |
 | `deployment.startAsRoot` | Starts core container as root and grants the fmeserver user access to the file system. | `false` |
+| `deployment.useHostnameIngress` | Configures the ingress to route traffic to FME Server only if the request matches the value of `deployment.hostname`. Setting this to false will route all traffic on the ingress to FME Server. | `true` |
 | `resources.core` | [Core CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `2Gi`, CPU: `200m` |
 | `resources.engine` | [Engine CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `512Mi`, CPU: `200m` |
 | `resources.queue` | [Queue CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `128Mi`, CPU: `100m` |
@@ -60,6 +61,7 @@ The following table lists the configurable parameters of the FME Server 2018.1.1
 | `deployment.numCores` | Number of cores to launch. Multi-core only works in a multi-host cluster with ReadWriteMany storage | `1` |
 | `deployment.numEngine` | Number of engines to launch. | `2` |
 | `deployment.startAsRoot` | Starts core container as root and grants the fmeserver user access to the file system. | `false` |
+| `deployment.useHostnameIngress` | Configures the ingress to route traffic to FME Server only if the request matches the value of `deployment.hostname`. Setting this to false will route all traffic on the ingress to FME Server. | `true` |
 | `resources.core` | [Core CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `2Gi`, CPU: `200m` |
 | `resources.engine` | [Engine CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `512Mi`, CPU: `200m` |
 | `resources.queue` | [Queue CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `128Mi`, CPU: `100m` |
@@ -94,6 +96,7 @@ The following table lists the configurable parameters of the FME Server 2018.1.0
 | `deployment.numCores` | Number of cores to launch. Multi-core only works in a multi-host cluster with ReadWriteMany storage | `1` |
 | `deployment.numEngine` | Number of engines to launch. | `2` |
 | `deployment.startAsRoot` | Starts core container as root and grants the fmeserver user access to the file system. | `false` |
+| `deployment.useHostnameIngress` | Configures the ingress to route traffic to FME Server only if the request matches the value of `deployment.hostname`. Setting this to false will route all traffic on the ingress to FME Server. | `true` |
 | `resources.core` | [Core CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `2Gi`, CPU: `200m` |
 | `resources.engine` | [Engine CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `512Mi`, CPU: `200m` |
 | `resources.queue` | [Queue CPU/Memory resource requests/limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Memory: `128Mi`, CPU: `100m` |

--- a/chart-source/fmeserver-2018.1.0/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/transact-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2018.1.0/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/transact-ingress.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverweb

--- a/chart-source/fmeserver-2018.1.0/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/transact-ingress.yaml
@@ -9,10 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverweb
@@ -26,3 +23,6 @@ spec:
               serviceName: fmeserverweb
               servicePort: 8080
             path: /fmerest/v3/transformations/transactdata
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2018.1.0/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/web-default-ingress.yaml
@@ -8,12 +8,12 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverweb
               servicePort: 8080
             path: /
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2018.1.0/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/web-default-ingress.yaml
@@ -8,8 +8,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverweb

--- a/chart-source/fmeserver-2018.1.0/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/web-default-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2018.1.0/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/websocket-ingress.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverwebsocket
               servicePort: 7078
             path: /websocket
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2018.1.0/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/websocket-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2018.1.0/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.0/templates/websocket-ingress.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverwebsocket

--- a/chart-source/fmeserver-2018.1.0/values.yaml
+++ b/chart-source/fmeserver-2018.1.0/values.yaml
@@ -11,7 +11,7 @@ deployment:
   numCores: 1
   numEngines: 2
   startAsRoot: false
-  singleServiceIngress: false
+  useHostnameIngress: true
 
 resources:
   core:

--- a/chart-source/fmeserver-2018.1.0/values.yaml
+++ b/chart-source/fmeserver-2018.1.0/values.yaml
@@ -11,6 +11,7 @@ deployment:
   numCores: 1
   numEngines: 2
   startAsRoot: false
+  singleServiceIngress: false
 
 resources:
   core:

--- a/chart-source/fmeserver-2018.1.1/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/transact-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2018.1.1/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/transact-ingress.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverweb

--- a/chart-source/fmeserver-2018.1.1/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/transact-ingress.yaml
@@ -9,10 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverweb
@@ -26,3 +23,6 @@ spec:
               serviceName: fmeserverweb
               servicePort: 8080
             path: /fmerest/v3/transformations/transactdata
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2018.1.1/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/web-default-ingress.yaml
@@ -8,12 +8,12 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverweb
               servicePort: 8080
             path: /
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2018.1.1/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/web-default-ingress.yaml
@@ -8,8 +8,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverweb

--- a/chart-source/fmeserver-2018.1.1/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/web-default-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2018.1.1/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/websocket-ingress.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverwebsocket
               servicePort: 7078
             path: /websocket
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2018.1.1/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/websocket-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2018.1.1/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2018.1.1/templates/websocket-ingress.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverwebsocket

--- a/chart-source/fmeserver-2018.1.1/values.yaml
+++ b/chart-source/fmeserver-2018.1.1/values.yaml
@@ -11,7 +11,7 @@ deployment:
   numCores: 1
   numEngines: 2
   startAsRoot: false
-  singleServiceIngress: false
+  useHostnameIngress: true
 
 resources:
   core:

--- a/chart-source/fmeserver-2018.1.1/values.yaml
+++ b/chart-source/fmeserver-2018.1.1/values.yaml
@@ -11,6 +11,7 @@ deployment:
   numCores: 1
   numEngines: 2
   startAsRoot: false
+  singleServiceIngress: false
 
 resources:
   core:

--- a/chart-source/fmeserver-2019.0.0-beta/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/transact-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2019.0.0-beta/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/transact-ingress.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverweb

--- a/chart-source/fmeserver-2019.0.0-beta/templates/transact-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/transact-ingress.yaml
@@ -9,10 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverweb
@@ -26,3 +23,6 @@ spec:
               serviceName: fmeserverweb
               servicePort: 8080
             path: /fmerest/v3/transformations/transactdata
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2019.0.0-beta/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/web-default-ingress.yaml
@@ -8,12 +8,12 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverweb
               servicePort: 8080
             path: /
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2019.0.0-beta/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/web-default-ingress.yaml
@@ -8,8 +8,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverweb

--- a/chart-source/fmeserver-2019.0.0-beta/templates/web-default-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/web-default-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2019.0.0-beta/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/websocket-ingress.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if .Values.deployment.useHostnameIngress }}
-    - host: {{ .Values.deployment.hostname }}
-      {{ else }}
-    - {{ end }}http:
+    - http:
         paths:
           - backend:
               serviceName: fmeserverwebsocket
               servicePort: 7078
             path: /websocket
+      {{- if .Values.deployment.useHostnameIngress }}
+      host: {{ .Values.deployment.hostname }}
+      {{ end }}

--- a/chart-source/fmeserver-2019.0.0-beta/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/websocket-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
-    {{- if not .Values.deployment.singleServiceIngress }}
+    {{- if .Values.deployment.useHostnameIngress }}
     - host: {{ .Values.deployment.hostname }}
       {{ else }}
     - {{ end }}http:

--- a/chart-source/fmeserver-2019.0.0-beta/templates/websocket-ingress.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/templates/websocket-ingress.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   {{- include "fmeserver.ingress.tls" . }}
   rules:
+    {{- if not .Values.deployment.singleServiceIngress }}
     - host: {{ .Values.deployment.hostname }}
-      http:
+      {{ else }}
+    - {{ end }}http:
         paths:
           - backend:
               serviceName: fmeserverwebsocket

--- a/chart-source/fmeserver-2019.0.0-beta/values.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/values.yaml
@@ -11,7 +11,7 @@ deployment:
   numCores: 1
   numEngines: 2
   startAsRoot: false
-  singleServiceIngress: false
+  useHostnameIngress: true
 
 resources:
   core:

--- a/chart-source/fmeserver-2019.0.0-beta/values.yaml
+++ b/chart-source/fmeserver-2019.0.0-beta/values.yaml
@@ -11,6 +11,7 @@ deployment:
   numCores: 1
   numEngines: 2
   startAsRoot: false
+  singleServiceIngress: false
 
 resources:
   core:


### PR DESCRIPTION
We currently configure the ingress to use [name based virtual hosting](https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting). This requires that the ingress controller's endpoint has DNS set up with a FQDN pointing at the ingress IP so that traffic can be routed based on hostname. This is great and absolutely the way we should deploy into a production cluster.

However it would be nice for testing purposes to set up the ingress rules to route all traffic regardless of the hostname or IP in the request. This is useful in cases where a temporary cluster has been set up that doesn't have any DNS set up pointing at it. This allows access to FME Server through the ingress IP directly.

This adds a new setting `deployment.useHostnameIngress` that can be set to false which will disable the host specification of the ingress to allow direct IP access.