### PR TITLE
Only build and publish charts for 2019.0

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -63,7 +63,9 @@ function get_remote_chart_version() {
 
 available_repos=`$HELM_BIN search safesoftware/`
 
-for chart_dir in chart-source/*/ ; do
+# From 2019.1 on we will be buildiing the charts internally and publishing them to this repo
+# We only want to build 2019.0.* using this script
+for chart_dir in chart-source/*2019.0*/ ; do
   chart_name=`get_chart_name $chart_dir`
   local_chart_version=`get_local_chart_version $chart_dir`
 


### PR DESCRIPTION
Starting with 2019.1, we will be building the helm charts internally at Safe and syncing them to this repository through a different process. I am updating this script to only package and index the 2019.0 charts.