### PR TITLE
added k8s service account and map to engine to support AWS-IRSA

### DIFF
--- a/chart-source/fmeserver-2021.1.0-beta/templates/engine-deployment.yaml
+++ b/chart-source/fmeserver-2021.1.0-beta/templates/engine-deployment.yaml
@@ -90,6 +90,11 @@ spec:
           resources:
 {{ toYaml .resources | indent 12 }}
           {{- end }}
+      {{- if $.Values.serviceAccount.create }}
+      serviceAccountName: "{{ $.Values.serviceAccount.awsAccountRole }}"
+      securityContext:
+        fsGroup: 65534
+      {{- end }}
       restartPolicy: Always
       volumes:
         - name: fmeserverdata

--- a/chart-source/fmeserver-2021.1.0-beta/templates/serviceaccount.yaml
+++ b/chart-source/fmeserver-2021.1.0-beta/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if $.Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ $.Values.serviceAccount.awsAccountRole }}"
+  labels:
+    safe.k8s.fmeserver.component: engine
+    {{- include "fmeserver.common.labels" $ | indent 4 }}
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ $.Values.serviceAccount.awsAccountId }}:role/{{ $.Values.serviceAccount.awsAccountRole }}  
+{{- end }}

--- a/chart-source/fmeserver-2021.1.0-beta/values.yaml
+++ b/chart-source/fmeserver-2021.1.0-beta/values.yaml
@@ -1,3 +1,9 @@
+serviceAccount:
+  # Specifies whether a ServiceAccount for FME-Engine should be created
+  create: false
+  awsAccountId: "123456789012"
+  awsAccountRole: "fme-engine-default"
+
 fmeserver:
   image:
     tag:


### PR DESCRIPTION
**Description of your changes**
Implements K8S ServiceAccount creation with Feature-Flag for FME-Engine to use AWS-IRSA

implements #64 

I have:

Run make reviewable test to ensure this PR is ready for review.
How has this code been tested:

helm unittest chart-source/fmeserver-2021.1.0-beta

_more detailed information:_

```
kubectl get sa fme-engine-default -o yaml  -n fme-dev
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/fme-engine-default
```

inside fme-engine:
```
fmeserver@engine-default-d44b98fb8-wmf6r:/fmeengine$ env | grep "AWS"
AWS_DEFAULT_REGION=eu-central-1
AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
AWS_REGION=eu-central-1
AWS_ROLE_ARN=arn:aws:iam::123456789012:role/fme-engine-default
```

cloudtrail access record:

```
   "eventVersion": "1.08",
    "userIdentity": {
        "type": "WebIdentityUser",
        "principalId": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-central-1.amazonaws.com/id/xxxxx:sts.amazonaws.com:system:serviceaccount:fme-dev:fme-engine-default",
        "userName": "system:serviceaccount:fme-dev:fme-engine-default",
        "identityProvider": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-central-1.amazonaws.com/id/xxxxx"
    },
    "eventTime": "2021-04-16T07:51:53Z",
    "eventSource": "sts.amazonaws.com",
    "eventName": "AssumeRoleWithWebIdentity",
    "awsRegion": "us-east-1",
    "sourceIPAddress": "1.2.3.4",
    "userAgent": "Boto3/1.10.16 Python/3.6.9 Linux/4.14.209-160.339.amzn2.x86_64 Botocore/1.13.16",
    "requestParameters": {
        "roleArn": "arn:aws:iam::123456789012:role/fme-engine-default",
        "roleSessionName": "botocore-session-1618559402"
    },
```

