### PR TITLE
Added possibility for additional storage mounts

### DIFF
--- a/chart-source/fmeserver-2022.0-beta/templates/additional-pv.yaml
+++ b/chart-source/fmeserver-2022.0-beta/templates/additional-pv.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.additionalStorage.useHostDir }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.additionalStorage.name | default "geodata"}}
+spec:
+  {{- with .Values.additionalStorage }}
+  capacity:
+    storage: {{ .fmeserver.size }}
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: {{ .reclaimPolicy }}
+  hostPath:
+    path: {{ .fmeserver.path | default "/tmp/k8s/geodata" }}
+    type: DirectoryOrCreate
+  {{- end }}
+{{- end}}

--- a/chart-source/fmeserver-2022.0-beta/templates/additional-pvc.yaml
+++ b/chart-source/fmeserver-2022.0-beta/templates/additional-pvc.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.additionalStorage }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    safe.k8s.fmeserver.component: data
+    {{- include "fmeserver.common.labels" . | indent 4 }}
+  name: {{ .Values.additionalStorage.name | default "geodata"}}
+spec:
+  {{- with .Values.additionalStorage }}
+  accessModes:
+  - {{ .fmeserver.accessMode }}
+  {{- if and (not .useHostDir) .fmeserver.class }}
+  storageClassName: {{ .fmeserver.class }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .fmeserver.size }}
+  {{- end }}
+{{- end }}

--- a/chart-source/fmeserver-2022.0-beta/templates/core-statefulset.yaml
+++ b/chart-source/fmeserver-2022.0-beta/templates/core-statefulset.yaml
@@ -45,6 +45,10 @@ spec:
           volumeMounts:
             - mountPath: /data/fmeserverdata
               name: fmeserverdata
+{{- if .Values.additionalStorage }}
+            - mountPath: {{ .Values.additionalStorage.mountPath | default "/opt/geodata" }}
+              name: {{ .Values.additionalStorage.name | default "geodata" }}
+{{- end }}
           env:
             - name: PRIMARY_PROCESS
               value: core
@@ -124,6 +128,10 @@ spec:
           volumeMounts:
             - mountPath: /data/fmeserverdata
               name: fmeserverdata
+            {{- if .Values.additionalStorage.enabled }}
+            - mountPath: {{ .Values.additionalStorage.mountPath }}
+              name: geodata
+            {{- end }}
           env:
             - name: FMESERVERHOSTNAME
               value: localhost

--- a/chart-source/fmeserver-2022.0-beta/templates/engine-deployment.yaml
+++ b/chart-source/fmeserver-2022.0-beta/templates/engine-deployment.yaml
@@ -35,6 +35,10 @@ spec:
           volumeMounts:
             - mountPath: /data/fmeserverdata
               name: fmeserverdata
+            {{- if $.Values.additionalStorage }}
+            - mountPath: {{ $.Values.additionalStorage.mountPath | default "/opt/geodata" }}
+              name: {{ $.Values.additionalStorage.name | default "geodata" }}
+            {{- end }}
           env:
             - name: EXTERNALHOSTNAME
               value: {{ $.Values.deployment.hostname }}

--- a/chart-source/fmeserver-2022.0-beta/values.yaml
+++ b/chart-source/fmeserver-2022.0-beta/values.yaml
@@ -69,7 +69,7 @@ deployment:
   numCores: 1
   startAsRoot: false
   useHostnameIngress: true
-  deployPostgresql: false
+  deployPostgresql: true
   disableTLS: false
   ingress:
     # general annotations are applied to all ingresses

--- a/chart-source/fmeserver-2022.0-beta/values.yaml
+++ b/chart-source/fmeserver-2022.0-beta/values.yaml
@@ -69,7 +69,7 @@ deployment:
   numCores: 1
   startAsRoot: false
   useHostnameIngress: true
-  deployPostgresql: true
+  deployPostgresql: false
   disableTLS: false
   ingress:
     # general annotations are applied to all ingresses
@@ -160,6 +160,17 @@ storage:
     size: 1Gi
     class:
     path:
+  fmeserver:
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    class:
+    path:
+
+additionalStorage:
+  useHostDir: false
+  reclaimPolicy: Delete
+  mountPath: /opt/geodata
+  name: geodata
   fmeserver:
     accessMode: ReadWriteOnce
     size: 10Gi


### PR DESCRIPTION
In a customer environment it has become necessary to provide an additional storage mount (for geodata) . The customer would very much prefer that the helm chart provided includes a possibility to mount additional storage that is not used otherwise in FME-Server. This PR aims to fulfill that request.