### PR TITLE
Fix name of legacy charts in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Helm Chart Rename
 
-Starting with FME Flow 2024.0, the helm chart has been renamed from having separate charts for each major release (e.g., `safesoftware/fmeserver-2023.1`, `safesoftware/fmeserver-2023.2`, etc) to having a single chart `safesoftware/fmeflow`.
+Starting with FME Flow 2024.0, the helm chart has been renamed from having separate charts for each major release (e.g., `safesoftware/fmeserver-2023-1`, `safesoftware/fmeserver-2023-2`, etc) to having a single chart `safesoftware/fmeflow`.
 
 This change is being made to make this repo less complex with so many versions of the chart. The new `fmeflow` chart will be made compatible with versions of FME Flow moving forward starting with 2024.0. If there are changes we need to make that will break backwards compatibility, we will increment the major version of this chart and will provide guidance to users on which versions of the chart to use with which versions of FME Flow. These types of changes should be very infrequent.
 


### PR DESCRIPTION
The last chart containing dots has been 2023.0 :
```
# helm search repo 2023
NAME                                    CHART VERSION   APP VERSION             DESCRIPTION
safesoftware/fmeserver-2023-0           0.2.61          2023.0.beta             FME Server 2023.0
safesoftware/fmeserver-2023-1           0.2.63          2023.1.beta             FME Server 2023.1
safesoftware/fmeserver-2023-1-beta      0.2.62          2023.1.beta BETA        FME Server 2023.1 BETA (this Chart is not upgra...
safesoftware/fmeserver-2023-2           0.2.67          2023.2.beta             FME Server 2023.2
safesoftware/fmeserver-2023-2-beta      0.2.67          2023.2.beta BETA        FME Server 2023.2 BETA (this Chart is not upgra...
safesoftware/fmeserver-2023.0           0.2.58          2023                    FME Server 2023.0
safesoftware/fmeserver-2023.0-beta      0.2.58          2023.0-beta BETA        FME Server 2023.0 BETA (this Chart is not upgra...
```

So the two given example names have to be ...2023-1 and ...2023-2 instead of .1 and .2.