### PR TITLE
Added possibility for additional storage mounts (again)

### DIFF
--- a/chart-source/fmeflow/templates/additional-pv.yaml
+++ b/chart-source/fmeflow/templates/additional-pv.yaml
@@ -1,0 +1,17 @@
+﻿{{ if .Values.additionalStorage.useHostDir }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.additionalStorage.name | default "geodata"}}
+spec:
+  {{- with .Values.additionalStorage }}
+  capacity:
+    storage: {{ .fmeflow.size }}
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: {{ .reclaimPolicy }}
+  hostPath:
+    path: {{ .fmeflow.path | default "/tmp/k8s/geodata" }}
+    type: DirectoryOrCreate
+  {{- end }}
+{{- end}}

--- a/chart-source/fmeflow/templates/additional-pvc.yaml
+++ b/chart-source/fmeflow/templates/additional-pvc.yaml
@@ -1,0 +1,20 @@
+﻿{{ if .Values.additionalStorage }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    safe.k8s.fmeflow.component: data
+    {{- include "fmeflow.common.labels" . | indent 4 }}
+  name: {{ .Values.additionalStorage.name | default "geodata"}}
+spec:
+  {{- with .Values.additionalStorage }}
+  accessModes:
+    - {{ .fmeflow.accessMode }}
+  {{- if and (not .useHostDir) .fmeflow.class }}
+  storageClassName: {{ .fmeflow.class }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .fmeflow.size }}
+  {{- end }}
+{{- end }}

--- a/chart-source/fmeflow/templates/core-statefulset.yaml
+++ b/chart-source/fmeflow/templates/core-statefulset.yaml
@@ -45,6 +45,10 @@ spec:
           volumeMounts:
             - mountPath: /data/fmeflowdata
               name: fmeflowdata
+          {{- if .Values.additionalStorage }}
+            - mountPath: {{ .Values.additionalStorage.mountPath | default "/opt/geodata" }}
+              name: {{ .Values.additionalStorage.name | default "geodata" }}
+          {{- end }}
           env:
             - name: PRIMARY_PROCESS
               value: core
@@ -144,6 +148,10 @@ spec:
           volumeMounts:
             - mountPath: /data/fmeflowdata
               name: fmeflowdata
+            {{- if .Values.additionalStorage }}
+            - mountPath: {{ .Values.additionalStorage.mountPath | default "/opt/geodata" }}
+              name: {{ .Values.additionalStorage.name | default "geodata" }}
+            {{- end }}
           env:
             - name: COREHOSTNAME
               value: localhost
@@ -303,6 +311,11 @@ spec:
         - name: fmeflowdata
           persistentVolumeClaim:
             claimName: {{ template "fmeflow.storage.data.claimName" . }}
+        {{- if $.Values.additionalStorage }}
+        - name: {{ $.Values.additionalStorage.name | default "geodata" }}
+          persistentVolumeClaim:
+            claimName: {{ $.Values.additionalStorage.name | default "geodata" }}
+        {{- end }}
       {{- if .Values.scheduling.core.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.scheduling.core.nodeSelector | indent 8 }}

--- a/chart-source/fmeflow/templates/engine-deployment.yaml
+++ b/chart-source/fmeflow/templates/engine-deployment.yaml
@@ -35,6 +35,10 @@ spec:
           volumeMounts:
             - mountPath: /data/fmeflowdata
               name: fmeflowdata
+          {{- if $.Values.additionalStorage }}
+            - mountPath: {{ $.Values.additionalStorage.mountPath | default "/opt/geodata" }}
+              name: {{ $.Values.additionalStorage.name | default "geodata" }}
+          {{- end }}
           env:
             - name: EXTERNALHOSTNAME
               value: {{ $.Values.deployment.hostname }}
@@ -172,6 +176,11 @@ spec:
         - name: fmeflowdata
           persistentVolumeClaim:
             claimName: {{ template "fmeflow.storage.data.claimName" $ }}
+        {{- if $.Values.additionalStorage }}
+        - name: {{ $.Values.additionalStorage.name | default "geodata" }}
+          persistentVolumeClaim:
+            claimName: {{ $.Values.additionalStorage.name | default "geodata" }}
+        {{- end }}
       affinity:
         {{- include "fmeflow.deployment.dataVolumeAffinity" $ | indent 8 }}
       {{- if .affinity }}

--- a/chart-source/fmeflow/values.yaml
+++ b/chart-source/fmeflow/values.yaml
@@ -179,6 +179,17 @@ storage:
     class:
     path:
 
+additionalStorage:
+  useHostDir: false
+  reclaimPolicy: Delete
+  mountPath: /opt/geodata
+  name: geodata
+  fmeflow:
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    class:
+    path:
+
 # It is recommended not to modify those parameters
 # For more options regarding PostgreSQL deployement, check the helm chart documentation:
 # https://github.com/bitnami/charts/tree/master/bitnami/postgresql


### PR DESCRIPTION
Basically the same PR as #76, all credit goes to @wilwer

We ran into the identical problem that was discussed in #76. We need to mount azure file storage into fme-form, additionally to the share we mount for fme itself, according to https://docs.safe.com/fme/html/FME-Flow/AdminGuide/Kubernetes/Kubernetes-Deploying-to-AKS.htm.

Fixed 2-3 bugs in the initial PR and updated for the new fmeform chart and naming schema.