### PR TITLE
Adding dynamic engine group and exposing engineProperties in values file

### DIFF
--- a/chart-source/fmeflow/Chart.yaml
+++ b/chart-source/fmeflow/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: For use with FME Flow 2024.1 and newer
 name: fmeflow
-version: 2.1.0
+version: 2.1.1

--- a/chart-source/fmeflow/values.yaml
+++ b/chart-source/fmeflow/values.yaml
@@ -66,6 +66,19 @@ fmeflow:
         affinity: {}
         nodeSelector: {}
         tolerations: []
+        engineProperties:
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 200m
+      - name: "dynamic-group"
+        engines: 0
+        type: "DYNAMIC"
+        labels: {}
+        affinity: {}
+        nodeSelector: {}
+        tolerations: []
+        engineProperties:
         resources:
           requests:
             memory: 512Mi


### PR DESCRIPTION
- adds a default dynamic engine group to values file with 0 scheduled engines
- expose `fmeflow.engines[].engineProperties` parameter in values file