### PR TITLE
add warning of upcoming bitnamilegacy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@
 
 This repository houses the helm charts for deploying FME Flow and the FME Flow Remote Engine Service. The remainder of this readme is focussed on the FME Flow Helm chart. To see the readme for the Remote Engine Service, see its [Readme](./README-RemoteEngine.md)
 
+## Important Notice: Bitnami PostgreSQL Chart Changes (August 28, 2025)
+
+**Bitnami is making changes to their PostgreSQL Helm chart and container images, scheduled for August 28, 2025.** After this date, only the latest PostgreSQL image tag will be available on Docker Hub, and older tags will be removed. This will impact users who rely on specific image tags for PostgreSQL.
+
+**What you need to do:**
+
+1. **Switch to the legacy image repository:**
+   - Set the image repository to `bitnamilegacy/postgresql` to continue using older tags.
+2. **Allow image substitutions:**
+   - The Bitnami chart will block deployment with image substitutions unless you set `global.security.allowInsecureImages=true`.
+
+You can do both in one command:
+
+```
+helm install ... \
+  --set postgresql.image.repository=bitnamilegacy/postgresql \
+  --set global.security.allowInsecureImages=true \
+  ...
+```
+
+Or in your `values.yaml`:
+
+```yaml
+global:
+  security:
+    allowInsecureImages: true
+postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+```
+
+If you do not make these changes, your deployments may fail to pull or start the required PostgreSQL image after August 28, 2025.
+
+For more details, see the [Bitnami announcement](https://github.com/bitnami/containers/issues/83267), [bitnamilegacy Docker Hub](https://hub.docker.com/r/bitnamilegacy/postgresql), and [Bitnami chart image verification documentation](https://github.com/bitnami/charts/issues/30850).
+
 ## Helm Chart Rename
 
 Starting with FME Flow 2024.0, the helm chart has been renamed from having separate charts for each major release (e.g., `safesoftware/fmeserver-2023-1`, `safesoftware/fmeserver-2023-2`, etc) to having a single chart `safesoftware/fmeflow`.


### PR DESCRIPTION
[FOUNDATION-8436]

Adds warning to existing users of upcoming changes to the Bitnami repository and the need to transition to the `bitnamilegacy` repository for continued functionality. Changes to the chart will be pushed shortly to incorporate these changes for new users of the chart. This will be a temporary solution until we transition to the official postgres image and are no longer dependant on the Bitnami chart.