### PR TITLE
Add unique name (selector) labels to each engine deployment group

### DIFF
--- a/chart-source/fmeflow/templates/engine-deployment.yaml
+++ b/chart-source/fmeflow/templates/engine-deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   labels:
     safe.k8s.fmeflow.component: engine
+    safe.k8s.fmeflow.engine-group: "{{ .name }}"
     {{- include "fmeflow.common.labels" $ | indent 4 }}
   name: "engine-{{ .name }}"
   {{- with $.Values.annotations.engine.deployment }}
@@ -15,10 +16,12 @@ spec:
   selector:
     matchLabels:
       safe.k8s.fmeflow.component: engine
+      safe.k8s.fmeflow.engine-group: "{{ .name }}"
   template:
     metadata:
       labels:
         safe.k8s.fmeflow.component: engine
+        safe.k8s.fmeflow.engine-group: "{{ .name }}"
         {{- include "fmeflow.common.labels" $ | indent 8 }}
         {{- with .labels }}
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
While setting up dynamic engine scaling with a KEDA HPA we ran into this issue:
`Warning  AmbiguousSelector: pods by selector safe.k8s.fmeflow.component=engine
         are controlled by multiple HPAs:
         [keda-hpa-fmeflow-default-scaler  keda-hpa-fmeflow-highmem-scaler]`

We are running multiple engine deployments and want to scale only two with different ScaledObjects , and because every engine deployment has a unique name but the same selector label _safe.k8s.fmeflow.component=engine_ there is an ambiguity.

This PR adds the engine deployment's name as a selector and metadata label to avoid this.